### PR TITLE
Adding SSL Certificate issuing/renewal

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/rchaganti/vsc-devcontainer-features/azurebicep:1": {},
-		"ghcr.io/azure/azure-dev/azd:0": {}
+		"ghcr.io/azure/azure-dev/azd:0": {},
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
 	},
 	"customizations": {
 		"vscode": {

--- a/.github/workflows/letsencrypt.yml
+++ b/.github/workflows/letsencrypt.yml
@@ -1,0 +1,79 @@
+name: Renew Let's Encrypt certificate (Wildcard)
+
+on:
+  workflow_dispatch:
+    inputs:
+      email: 
+        description: 'eMail account to use for Let''s Encrypt certificate'
+        required: true
+
+jobs:
+  renew-letsencrypt-certificate:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Login to Azure using OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_LETS_ENCRYPT_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Test Keyvault DNS resolution
+        run: |
+          az deployment sub create --verbose --location italynorth --template-file letsencrypt/main.bicep \
+            --parameters mainDnsZoneResourceId=${{ inputs.DNS_ZONE_RESOURCE_ID }} \
+            mainCertKeyVaultResourceId=${{ inputs.KEY_VAULT_RESOURCE_ID }} \
+            domain=${{ vars.DOMAIN_NAME }}
+
+      - name: Setup azuredns.ini
+        run: |
+          az deployment sub show --name main --query properties.outputs.azurednsini.value -o tsv > azuredns.ini
+
+      - name: Build and Push customer Docker image
+        run: |
+          docker build . -t $(az deployment sub show --name main --query properties.outputs.registryServername.value -o tsv)/h2floh/azurecertbot:latest
+          az acr login -n $(az deployment sub show --name main --query properties.outputs.registryServername.value -o tsv)
+          docker push $(az deployment sub show --name main --query properties.outputs.registryServername.value -o tsv)/h2floh/azurecertbot:latest
+        working-directory: letsencrypt
+
+      - name: Run Container Instance to renew certificate and store
+        run: |
+          az deployment sub create --verbose --location italynorth --template-file ./aci.bicep \
+            --parameters mainCertKeyVaultResourceId=${{ inputs.KEY_VAULT_RESOURCE_ID }} \
+            email=${{ secrets.LETS_ENCRYPT_EMAIL }} \
+            domain=${{ vars.DOMAIN_NAME }} \
+            certname=${{ vars.KEY_VAULT_CERT_NAME }} \
+            production=${{ vars.PRODUCTION }} \
+            registryServername=$(az deployment sub show --name main --query properties.outputs.registryServername.value -o tsv) \
+            userAssignedIdentityPrincipalId=$(az deployment sub show --name main --query properties.outputs.umsiPrincipalId.value -o tsv) \
+            userAssignedIdentityResourceId=$(az deployment sub show --name main --query properties.outputs.umsiResourceId.value -o tsv)
+
+
+  cleanup-environment:
+    depends-on: renew-letsencrypt-certificate
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Login to Azure using OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_LETS_ENCRYPT_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  
+      # - name: Cleanup environment
+      #   run: |
+      #     az group delete --name rg-temporary --yes

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 id_rsa.pub
+azuredns.ini
+letsencrypt/.cheetsheet

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -32,5 +32,7 @@ ENV KEY_VAULT_NAME=keyvaultname
 ENV KEY_VAULT_CERT_NAME=mycertname
 # Mandatory for issuing a real SSL certificate (0 = Testing)
 ENV PRODUCTION=0
+# Mandatory User Manage Identity
+ENV USERNAME=usermanagedidentityclientid
 
-CMD [ "/bin/bash", "/start.sh" ]
+CMD [ "/bin/bash", "/start.sh"]

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu
+
+# Update repository
+RUN apt-get -y update
+# Install Certbot
+RUN apt-get -y install certbot
+# Install Certbot DNS plugin for Azure
+RUN apt-get -y install python3-pip
+RUN pip3 install --break-system-packages certbot certbot-dns-azure
+# Install PWGEN
+RUN apt-get -y install pwgen
+# Install cURL
+RUN apt-get -y install curl
+# Install Azure CLI with one command
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash -
+
+# WORKDIR
+WORKDIR /
+
+# Copy scripts
+COPY start.sh /
+COPY azuredns.ini /
+
+# Environment Variables/Parameters which can be set
+# Mandatory
+ENV YOUR_CERTIFICATE_EMAIL=yourcertificatemail 
+# Mandatory
+ENV YOUR_DOMAIN=yourdomainvalue
+# Mandatory
+ENV KEY_VAULT_NAME=keyvaultname
+# Mandatory
+ENV KEY_VAULT_CERT_NAME=mycertname
+# Mandatory for issuing a real SSL certificate (0 = Testing)
+ENV PRODUCTION=0
+
+CMD [ "/bin/bash", "/start.sh" ]

--- a/letsencrypt/aci.bicep
+++ b/letsencrypt/aci.bicep
@@ -1,0 +1,85 @@
+targetScope = 'subscription'
+
+param resourceLocation string = 'italynorth'
+param mainCertKeyVaultResourceId string
+param registryServername string
+param userAssignedIdentity string
+param email string
+param domain string
+param certname string
+param production string = '0'
+
+resource rgtemp 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-temporary'
+  location: resourceLocation
+}
+
+module containerGroup 'br/public:avm/res/container-instance/container-group:0.4.2' = {
+  scope: rgtemp
+  name: '${uniqueString(deployment().name, resourceLocation)}-aci'
+  params: {
+    // Required parameters
+    containers: [
+      {
+        name: 'letsencrypt'
+        properties: {
+          image: '${registryServername}/h2floh/azurecertbot:latest'
+          ports: [
+            {
+              port: 443
+              protocol: 'Tcp'
+            }
+          ]
+          resources: {
+            requests: {
+              cpu: 2
+              memoryInGB: '2'
+            }
+          }
+          environmentVariables: [
+            {
+              name: 'YOUR_CERTIFICATE_EMAIL'
+              value: email
+            }
+            {
+              name: 'YOUR_DOMAIN'
+              value: domain
+            }
+            {
+              name: 'KEY_VAULT_NAME'
+              value: split(mainCertKeyVaultResourceId, '/')[8]
+            }
+            {
+              name: 'KEY_VAULT_CERT_NAME'
+              value: certname
+            }
+            {
+              name: 'PRODUCTION'
+              value: production
+            }         
+          ]
+        }
+      }
+    ]
+    name: 'aci-${uniqueString(deployment().name, resourceLocation)}'
+    // Non-required parameters
+    ipAddressPorts: [
+      {
+        port: 443
+        protocol: 'Tcp'
+      }
+    ]
+    imageRegistryCredentials: [
+      {
+        server: registryServername
+        identity: userAssignedIdentity
+      }
+    ]
+    location: resourceLocation
+    managedIdentities: {
+      systemAssigned: false
+      userAssignedResourceIds: [userAssignedIdentity]
+    }
+    restartPolicy: 'Always'
+  }
+}

--- a/letsencrypt/aci.bicep
+++ b/letsencrypt/aci.bicep
@@ -3,7 +3,8 @@ targetScope = 'subscription'
 param resourceLocation string = 'italynorth'
 param mainCertKeyVaultResourceId string
 param registryServername string
-param userAssignedIdentity string
+param userAssignedIdentityPrincipalId string
+param userAssignedIdentityResourceId string
 param email string
 param domain string
 param certname string
@@ -57,6 +58,10 @@ module containerGroup 'br/public:avm/res/container-instance/container-group:0.4.
               name: 'PRODUCTION'
               value: production
             }         
+            {
+              name: 'USERNAME'
+              value: userAssignedIdentityPrincipalId
+            }
           ]
         }
       }
@@ -72,14 +77,14 @@ module containerGroup 'br/public:avm/res/container-instance/container-group:0.4.
     imageRegistryCredentials: [
       {
         server: registryServername
-        identity: userAssignedIdentity
+        identity: userAssignedIdentityResourceId
       }
     ]
     location: resourceLocation
     managedIdentities: {
       systemAssigned: false
-      userAssignedResourceIds: [userAssignedIdentity]
+      userAssignedResourceIds: [userAssignedIdentityResourceId]
     }
-    restartPolicy: 'Always'
+    restartPolicy: 'Never'
   }
 }

--- a/letsencrypt/azuredns.ini.sample
+++ b/letsencrypt/azuredns.ini.sample
@@ -1,4 +1,6 @@
-dns_azure_msi_client_id = 912ce44a-0156-4669-ae22-c16a17d34ca5
+dns_azure_use_cli_credentials = true
+
+dns_azure_environment = "AzurePublicCloud"
 
 dns_azure_zone1 = example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1
 dns_azure_zone2 = example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2

--- a/letsencrypt/azuredns.ini.sample
+++ b/letsencrypt/azuredns.ini.sample
@@ -1,0 +1,4 @@
+dns_azure_msi_client_id = 912ce44a-0156-4669-ae22-c16a17d34ca5
+
+dns_azure_zone1 = example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1
+dns_azure_zone2 = example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2

--- a/letsencrypt/certbot.bicep
+++ b/letsencrypt/certbot.bicep
@@ -1,0 +1,86 @@
+param resourceLocation string = 'italynorth'
+param mainDnsZoneResourceId string = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-dns/providers/Microsoft.Network/dnszones/domain.com'
+param mainCertKeyVaultResourceId string = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-dns/providers/Microsoft.KeyVault/vaults/vaultname'
+param rgdns string = split(mainDnsZoneResourceId, '/')[4]
+
+module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.4.0' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-umsi'
+  params: {
+    // Required parameters
+    name: 'umsi-${uniqueString(deployment().name, resourceLocation)}'
+    // Non-required parameters
+    location: resourceLocation
+    federatedIdentityCredentials: [
+      {
+        audiences: [
+          'api://AzureADTokenExchange'
+        ]
+        issuer: 'https://token.actions.githubusercontent.com'
+        name: 'GitHubWorkflowDefault'
+        subject: 'repo:flowsoft-org/azure-verified-modules:ref:refs/heads/main'
+      }
+      {
+        audiences: [
+          'api://AzureADTokenExchange'
+        ]
+        issuer: 'https://token.actions.githubusercontent.com'
+        name: 'GitHubWorkflowTest'
+        subject: 'repo:flowsoft-org/azure-verified-modules:ref:refs/heads/h2floh/letsencrypt'
+      }
+    ]
+  }
+}
+
+module registry 'br/public:avm/res/container-registry/registry:0.7.0' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-acr'
+  params: {
+    // Required parameters
+    name: 'acr${uniqueString(deployment().name, resourceLocation)}'
+    // Non-required parameters
+    acrSku: 'Basic'
+    location: resourceLocation
+    roleAssignments: [
+      {
+        principalId: userAssignedIdentity.outputs.principalId
+        roleDefinitionIdOrName: 'AcrPull'
+      }
+      {
+        principalId: userAssignedIdentity.outputs.principalId
+        roleDefinitionIdOrName: 'AcrPush'
+      }
+    ]
+  }
+}
+
+module dnsmsiRoleAssignment 'br/public:avm/ptn/authorization/resource-role-assignment:0.1.2' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-dnsrole'
+  scope: resourceGroup(rgdns)
+  params: {
+    // Required parameters
+    principalId: userAssignedIdentity.outputs.principalId
+    resourceId: mainDnsZoneResourceId
+    roleDefinitionId: 'befefa01-2a29-4197-83a8-272ff33ce314' // 'DNS Zone Contributor'
+    // Non-required parameters
+    description: 'Role assignment for certbot'
+    principalType: 'ServicePrincipal'
+  }
+}
+
+module kvmsiRoleAssignment 'br/public:avm/ptn/authorization/resource-role-assignment:0.1.2' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-kvrole'
+  scope: resourceGroup(rgdns)
+  params: {
+    // Required parameters
+    principalId: userAssignedIdentity.outputs.principalId
+    resourceId: mainCertKeyVaultResourceId
+    roleDefinitionId: 'a4417e6f-fecd-4de8-b567-7b0420556985' // 'Key Vault Certificates Officer'
+    // Non-required parameters
+    description: 'Role assignment for certbot'
+    principalType: 'ServicePrincipal'
+  }
+}
+
+
+output registryServername string = registry.outputs.loginServer
+output umsiResourceId string = userAssignedIdentity.outputs.resourceId
+output umsiPrincipalId string = userAssignedIdentity.outputs.principalId

--- a/letsencrypt/main.bicep
+++ b/letsencrypt/main.bicep
@@ -1,0 +1,25 @@
+targetScope = 'subscription'
+
+param resourceLocation string = 'italynorth'
+param mainDnsZoneResourceId string
+param mainCertKeyVaultResourceId string
+param domain string
+
+resource rgtemp 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-temporary'
+  location: resourceLocation
+}
+
+module certbotResources './certbot.bicep' = {
+  scope: rgtemp
+  name: '${uniqueString(deployment().name, resourceLocation)}-certbot'
+  params: {
+    resourceLocation: resourceLocation
+    mainDnsZoneResourceId: mainDnsZoneResourceId
+    mainCertKeyVaultResourceId: mainCertKeyVaultResourceId
+  }
+}
+
+output umsi string = certbotResources.outputs.umsiResourceId
+output registryServername string = certbotResources.outputs.registryServername
+output azurednsini string = 'dns_azure_msi_client_id = ${certbotResources.outputs.umsiPrincipalId}\ndns_azure_zone1 = ${substring(domain, 2)}:${split(mainDnsZoneResourceId,'/providers')[0]}'

--- a/letsencrypt/main.bicep
+++ b/letsencrypt/main.bicep
@@ -20,6 +20,7 @@ module certbotResources './certbot.bicep' = {
   }
 }
 
-output umsi string = certbotResources.outputs.umsiResourceId
+output umsiResourceId string = certbotResources.outputs.umsiResourceId
+output umsiPrincipalId string = certbotResources.outputs.umsiPrincipalId
 output registryServername string = certbotResources.outputs.registryServername
-output azurednsini string = 'dns_azure_msi_client_id = ${certbotResources.outputs.umsiPrincipalId}\ndns_azure_zone1 = ${substring(domain, 2)}:${split(mainDnsZoneResourceId,'/providers')[0]}'
+output azurednsini string = 'dns_azure_use_cli_credentials = true\ndns_azure_environment = "AzurePublicCloud"\ndns_azure_zone1 = ${domain}:${split(mainDnsZoneResourceId,'/providers')[0]}'

--- a/letsencrypt/start.sh
+++ b/letsencrypt/start.sh
@@ -2,15 +2,21 @@
 
 # Azure Login
 echo "Login to Azure CLI..."
-az login --identity --allow-no-subscriptions 2> azcli.err
+az login --identity --username $USERNAME --allow-no-subscriptions 2> azcli.err
+while [ $? -ne 0 ]
+do
+  echo "User Managed Identity not yet propagated. Waiting 10 seconds"
+  sleep 10s
+  az login --identity --username $USERNAME --allow-no-subscriptions 2> azcli.err
+done
 
 # Execute Let's Encrypt cert issuing process
 if [ $PRODUCTION -eq 0 ]; then
   echo "Try issuing certificate from Let's Encrypt (Staging)..."
-  certbot certonly --authenticator dns-azure --preferred-challenges dns --dns-azure-config azuredns.ini --non-interactive --agree-tos --email $YOUR_CERTIFICATE_EMAIL --domains $YOUR_DOMAIN --staging 
+  certbot certonly --authenticator dns-azure --preferred-challenges dns --dns-azure-config azuredns.ini --non-interactive --agree-tos --email $YOUR_CERTIFICATE_EMAIL --domains *.$YOUR_DOMAIN --dns-azure-propagation-seconds 20 --staging 
 else
     echo "Try issuing certificate from Let's Encrypt (Production)..."
-  certbot certonly --authenticator dns-azure --preferred-challenges dns --dns-azure-config azuredns.ini --non-interactive --agree-tos --email $YOUR_CERTIFICATE_EMAIL --domains $YOUR_DOMAIN 
+  certbot certonly --authenticator dns-azure --preferred-challenges dns --dns-azure-config azuredns.ini --non-interactive --agree-tos --email $YOUR_CERTIFICATE_EMAIL --domains *.$YOUR_DOMAIN --dns-azure-propagation-seconds 20 
 fi
 
 # Create Temp Password

--- a/letsencrypt/start.sh
+++ b/letsencrypt/start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Azure Login
+echo "Login to Azure CLI..."
+az login --identity --allow-no-subscriptions 2> azcli.err
+
+# Execute Let's Encrypt cert issuing process
+if [ $PRODUCTION -eq 0 ]; then
+  echo "Try issuing certificate from Let's Encrypt (Staging)..."
+  certbot certonly --authenticator dns-azure --preferred-challenges dns --dns-azure-config azuredns.ini --non-interactive --agree-tos --email $YOUR_CERTIFICATE_EMAIL --domains $YOUR_DOMAIN --staging 
+else
+    echo "Try issuing certificate from Let's Encrypt (Production)..."
+  certbot certonly --authenticator dns-azure --preferred-challenges dns --dns-azure-config azuredns.ini --non-interactive --agree-tos --email $YOUR_CERTIFICATE_EMAIL --domains $YOUR_DOMAIN 
+fi
+
+# Create Temp Password
+PFX_EXPORT_PASSWORD=$(pwgen 14 1 -c -n -y)
+# Create PFX file
+echo "Try create certificate..."
+cp /etc/letsencrypt/live/$YOUR_DOMAIN/* .
+openssl pkcs12 -inkey /privkey.pem -in /fullchain.pem -export -out /sslcert.pfx -passout pass:"$PFX_EXPORT_PASSWORD"
+echo "Done"
+
+# Upload to KeyVault
+echo "Import SSL Certificate to KeyVault..."
+az keyvault certificate import --vault-name $KEY_VAULT_NAME -n $KEY_VAULT_CERT_NAME -f /sslcert.pfx --password $PFX_EXPORT_PASSWORD 2> azkeyvault.err
+while [ $? -ne 0 ]
+do
+  echo "Rights not available. Waiting 10 seconds"
+  sleep 10s
+  az keyvault certificate import --vault-name $KEY_VAULT_NAME -n $KEY_VAULT_CERT_NAME -f /sslcert.pfx --password $PFX_EXPORT_PASSWORD 2> azkeyvault.err
+done
+echo "Import successful."


### PR DESCRIPTION
This pull request introduces several changes aimed at automating the renewal of Let's Encrypt certificates using Azure resources. The changes include the addition of a GitHub Actions workflow, Dockerfile for a custom container image, and several Bicep templates for Azure deployment.

The most important changes include:

### Automation of Let's Encrypt Certificate Renewal:

* [`.github/workflows/letsencrypt.yml`](diffhunk://#diff-7669010bfcac583ea138a267bce59b765008b8628c8f0c4614a977ca8eef6d71R1-R79): Added a new GitHub Actions workflow to automate the renewal of Let's Encrypt certificates using Azure resources. This workflow includes steps for logging into Azure, testing DNS resolution, building and pushing a Docker image, and running a container instance to renew the certificate.

### Docker Configuration:

* [`letsencrypt/Dockerfile`](diffhunk://#diff-4095ab6a98e5ecde40b084756a304abc5bc3b35a2d07acdca461ee56dbd5d127R1-R38): Created a Dockerfile to build a custom container image with necessary tools such as Certbot, Azure CLI, and other dependencies required for the certificate renewal process.

### Azure Bicep Templates:

* [`letsencrypt/aci.bicep`](diffhunk://#diff-702bb1c1ddde16635a009afd5b92727118168551e4174bf1639d44d02be253e4R1-R90): Added a Bicep template to deploy an Azure Container Instance that runs the certificate renewal process. This template includes parameters for various Azure resources and environment variables.
* [`letsencrypt/certbot.bicep`](diffhunk://#diff-b0eefe997fe71cc40903a9881cd8d50ba06aa55184e8293364c49219b1386c80R1-R86): Added a Bicep template to create necessary Azure resources such as a user-assigned managed identity and container registry, and to assign roles for DNS and Key Vault access.
* [`letsencrypt/main.bicep`](diffhunk://#diff-d5da39886f82cab167fce44be08c9a4c4449bed5b376e9bd30a710cbae1dab8bR1-R26): Added a main Bicep template to deploy the `certbot.bicep` module and output necessary information for subsequent steps.

### Sample Configuration:

* [`letsencrypt/azuredns.ini.sample`](diffhunk://#diff-44ea5f6fdacf4fc1002303a02ea3cef218466d9db5c431955295e6ed5b28fef6R1-R4): Added a sample configuration file for the Azure DNS plugin used by Certbot, specifying client IDs and DNS zones.

These changes collectively enable the automation of the Let's Encrypt certificate renewal process using GitHub Actions and Azure resources.