### PR TITLE
Fixing Lets encrypt renewal workflow until it worked

### DIFF
--- a/.github/workflows/letsencrypt.yml
+++ b/.github/workflows/letsencrypt.yml
@@ -3,6 +3,8 @@ name: Renew Let's Encrypt certificate (Wildcard)
 on:
   workflow_dispatch:
 
+
+
 jobs:
   renew-letsencrypt-certificate:
     runs-on: ubuntu-latest
@@ -10,6 +12,14 @@ jobs:
     permissions:
       id-token: write
       contents: read
+
+    env:
+      DNS_ZONE_RESOURCE_ID: ${{ vars.DNS_ZONE_RESOURCE_ID }}
+      KEY_VAULT_RESOURCE_ID: ${{ vars.KEY_VAULT_RESOURCE_ID }}
+      DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
+      KEY_VAULT_CERT_NAME: ${{ vars.KEY_VAULT_CERT_NAME }}
+      PRODUCTION: ${{ vars.PRODUCTION }}
+      LETS_ENCRYPT_EMAIL: ${{ secrets.LETS_ENCRYPT_EMAIL }}
 
     steps:
       - name: Checkout repository
@@ -22,12 +32,12 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Test Keyvault DNS resolution
+      - name: Prepare infrastructure, role assignments and prerequisites
         run: |
           az deployment sub create --verbose --location italynorth --template-file letsencrypt/main.bicep \
-            --parameters mainDnsZoneResourceId=${{ inputs.DNS_ZONE_RESOURCE_ID }} \
-            mainCertKeyVaultResourceId=${{ inputs.KEY_VAULT_RESOURCE_ID }} \
-            domain=${{ vars.DOMAIN_NAME }}
+            --parameters mainDnsZoneResourceId=$DNS_ZONE_RESOURCE_ID \
+            mainCertKeyVaultResourceId=$KEY_VAULT_RESOURCE_ID \
+            domain=$DOMAIN_NAME
 
       - name: Setup azuredns.ini
         run: |
@@ -43,11 +53,11 @@ jobs:
       - name: Run Container Instance to renew certificate and store
         run: |
           az deployment sub create --verbose --location italynorth --template-file ./aci.bicep \
-            --parameters mainCertKeyVaultResourceId=${{ inputs.KEY_VAULT_RESOURCE_ID }} \
-            email=${{ secrets.LETS_ENCRYPT_EMAIL }} \
-            domain=${{ vars.DOMAIN_NAME }} \
-            certname=${{ vars.KEY_VAULT_CERT_NAME }} \
-            production=${{ vars.PRODUCTION }} \
+            --parameters mainCertKeyVaultResourceId=$KEY_VAULT_RESOURCE_ID \
+            email=$LETS_ENCRYPT_EMAIL \
+            domain=$DOMAIN_NAME \
+            certname=$KEY_VAULT_CERT_NAME \
+            production=$PRODUCTION \
             registryServername=$(az deployment sub show --name main --query properties.outputs.registryServername.value -o tsv) \
             userAssignedIdentityPrincipalId=$(az deployment sub show --name main --query properties.outputs.umsiPrincipalId.value -o tsv) \
             userAssignedIdentityResourceId=$(az deployment sub show --name main --query properties.outputs.umsiResourceId.value -o tsv)

--- a/.github/workflows/letsencrypt.yml
+++ b/.github/workflows/letsencrypt.yml
@@ -63,10 +63,17 @@ jobs:
             userAssignedIdentityPrincipalId=$(az deployment sub show --name main --query properties.outputs.umsiPrincipalId.value -o tsv) \
             userAssignedIdentityResourceId=$(az deployment sub show --name main --query properties.outputs.umsiResourceId.value -o tsv)
 
+      - name: Cleanup when completed
+        timeout-minutes: 5
+        run: |
+          while [ "$(az container show --ids $(az deployment sub show --name aci --query properties.outputs.aciResourceId.value -o tsv) --query containers[0].instanceView.currentState.detailStatus -tsv o)" != "Completed" ]; do
+            sleep 30
+          done
+          az group delete --name rg-temporary --yes
 
-  cleanup-environment:
+  cleanup-environment-on-failure:
     needs: renew-letsencrypt-certificate
-    if: ${{ always() }}
+    if: ${{ failure() }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -81,6 +88,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   
-      # - name: Cleanup environment
-      #   run: |
-      #     az group delete --name rg-temporary --yes
+      - name: Cleanup environment
+        run: |
+          az group delete --name rg-temporary --yes

--- a/.github/workflows/letsencrypt.yml
+++ b/.github/workflows/letsencrypt.yml
@@ -2,10 +2,6 @@ name: Renew Let's Encrypt certificate (Wildcard)
 
 on:
   workflow_dispatch:
-    inputs:
-      email: 
-        description: 'eMail account to use for Let''s Encrypt certificate'
-        required: true
 
 jobs:
   renew-letsencrypt-certificate:
@@ -58,7 +54,7 @@ jobs:
 
 
   cleanup-environment:
-    depends-on: renew-letsencrypt-certificate
+    needs: renew-letsencrypt-certificate
     if: ${{ always() }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/letsencrypt.yml
+++ b/.github/workflows/letsencrypt.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Setup azuredns.ini
         run: |
           az deployment sub show --name main --query properties.outputs.azurednsini.value -o tsv > azuredns.ini
+        working-directory: letsencrypt
 
       - name: Build and Push customer Docker image
         run: |

--- a/.github/workflows/letsencrypt.yml
+++ b/.github/workflows/letsencrypt.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run Container Instance to renew certificate and store
         run: |
-          az deployment sub create --verbose --location italynorth --template-file ./aci.bicep \
+          az deployment sub create --verbose --location italynorth --template-file letsencrypt/aci.bicep \
             --parameters mainCertKeyVaultResourceId=$KEY_VAULT_RESOURCE_ID \
             email=$LETS_ENCRYPT_EMAIL \
             domain=$DOMAIN_NAME \

--- a/.github/workflows/letsencrypt.yml
+++ b/.github/workflows/letsencrypt.yml
@@ -64,7 +64,7 @@ jobs:
             userAssignedIdentityResourceId=$(az deployment sub show --name main --query properties.outputs.umsiResourceId.value -o tsv)
 
       - name: Cleanup when completed
-        timeout-minutes: 5
+        timeout-minutes: 3
         run: |
           while [ "$(az container show --ids $(az deployment sub show --name aci --query properties.outputs.aciResourceId.value -o tsv) --query containers[0].instanceView.currentState.detailStatus -o tsv)" != "Completed" ]; do
             sleep 30

--- a/.github/workflows/letsencrypt.yml
+++ b/.github/workflows/letsencrypt.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Cleanup when completed
         timeout-minutes: 5
         run: |
-          while [ "$(az container show --ids $(az deployment sub show --name aci --query properties.outputs.aciResourceId.value -o tsv) --query containers[0].instanceView.currentState.detailStatus -tsv o)" != "Completed" ]; do
+          while [ "$(az container show --ids $(az deployment sub show --name aci --query properties.outputs.aciResourceId.value -o tsv) --query containers[0].instanceView.currentState.detailStatus -o tsv)" != "Completed" ]; do
             sleep 30
           done
           az group delete --name rg-temporary --yes

--- a/letsencrypt/aci.bicep
+++ b/letsencrypt/aci.bicep
@@ -88,3 +88,5 @@ module containerGroup 'br/public:avm/res/container-instance/container-group:0.4.
     restartPolicy: 'Never'
   }
 }
+
+output aciResourceId string = containerGroup.outputs.resourceId


### PR DESCRIPTION
This pull request includes several updates to the Let's Encrypt certificate renewal workflow in the `.github/workflows/letsencrypt.yml` file. The changes focus on simplifying the workflow configuration and improving the environment cleanup process.

Workflow configuration updates:

* Removed the `inputs` section for `email` in the `workflow_dispatch` trigger.
* Added environment variables (`env`) for DNS zone, key vault, domain name, certificate name, production flag, and Let's Encrypt email.
* Updated the `Prepare infrastructure, role assignments and prerequisites` step to use environment variables instead of workflow inputs.
* Updated the `Run Container Instance to renew certificate and store` step to use environment variables instead of workflow inputs.

Environment cleanup improvements:

* Added a `Cleanup when completed` step to delete the temporary resource group after the container instance completes.
* Replaced the `cleanup-environment` job with `cleanup-environment-on-failure` to handle failures and added back the `Cleanup environment` step.

Additionally, an output for `aciResourceId` was added to the `letsencrypt/aci.bicep` file to facilitate resource management.